### PR TITLE
Use the official ruby/setup-ruby@v1

### DIFF
--- a/compile-assets/action.yml
+++ b/compile-assets/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Check if assets are already compiled
       id: check-asset-cache
-      uses: useblacksmith/cache/restore@v5
+      uses: actions/cache/restore@v4
       with:
         path: |
           public/assets
@@ -47,7 +47,7 @@ runs:
     - name: Cache Rails Precompiled Assets
       if: steps.check-asset-cache.outputs.cache-hit != 'true'
       id: lookup-cached-assets
-      uses: useblacksmith/cache/save@v5
+      uses: actions/cache/save@v4
       with:
         path: |
           public/assets

--- a/compile-assets/action.yml
+++ b/compile-assets/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Set up node
       if: steps.check-asset-cache.outputs.cache-hit != 'true'
-      uses: useblacksmith/setup-node@v5
+      uses: actions/setup-node@v4
       with:
         node-version-file: .node-version
         cache: yarn

--- a/linting-and-non-system-tests/action.yml
+++ b/linting-and-non-system-tests/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Retrieve Cached Rails Assets
       id: cache-assets
-      uses: useblacksmith/cache/restore@v5
+      uses: actions/cache/restore@v4
       with:
         path: |
           public/assets
@@ -47,7 +47,7 @@ runs:
 
     - name: Load previous turbo test runtime stats
       id: restore-parallel-spec
-      uses: useblacksmith/cache@v5
+      uses: actions/cache/restore@v4
       with:
         path: tmp/turbo_rspec_runtime.log
         key: parallel-spec-non-system-runtimes-${{ github.sha }}_${{ github.run_attempt }}

--- a/linting-and-non-system-tests/action.yml
+++ b/linting-and-non-system-tests/action.yml
@@ -21,7 +21,7 @@ runs:
       run: corepack enable
 
     - name: Set up node
-      uses: useblacksmith/setup-node@v5
+      uses: actions/setup-node@v4
       with:
         node-version-file: .node-version
         cache: yarn

--- a/linting-and-non-system-tests/action.yml
+++ b/linting-and-non-system-tests/action.yml
@@ -31,7 +31,7 @@ runs:
       run: yarn install --immutable
 
     - name: Install Ruby and gems
-      uses: useblacksmith/setup-ruby@v2
+      uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
 

--- a/system-tests/action.yml
+++ b/system-tests/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Retrieve Cached Rails Assets
       id: cache-assets
-      uses: useblacksmith/cache/restore@v5
+      uses: actions/cache/restore@v4
       with:
         path: |
           public/assets
@@ -46,7 +46,7 @@ runs:
 
     - name: Load previous turbo test runtime stats
       id: restore-parallel-spec
-      uses: useblacksmith/cache@v5
+      uses: actions/cache/restore@v4
       with:
         path: tmp/turbo_rspec_runtime.log
         key: parallel-spec-system-runtimes-${{ github.sha }}_${{ github.run_attempt }}

--- a/system-tests/action.yml
+++ b/system-tests/action.yml
@@ -13,7 +13,7 @@ runs:
       run: corepack enable
 
     - name: Set up node
-      uses: useblacksmith/setup-node@v5
+      uses: actions/setup-node@v4
       with:
         node-version-file: .node-version
         cache: yarn

--- a/system-tests/action.yml
+++ b/system-tests/action.yml
@@ -23,7 +23,7 @@ runs:
       run: yarn install --immutable
 
     - name: Install Ruby and gems
-      uses: useblacksmith/setup-ruby@v2
+      uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
 


### PR DESCRIPTION
Use the official packages now that the blacksmith actions are [deprecated](https://docs.blacksmith.sh/blacksmith-caching/dependencies-actions#actions-cache-v1-deprecated). See also https://www.blacksmith.sh/blog/cache

<img width="701" height="232" alt="image" src="https://github.com/user-attachments/assets/fbdd3d70-84ad-4bd1-ac32-c357b1e59371" />
