### PR TITLE
Fix turbo-test runtime cache never being saved

### DIFF
--- a/linting-and-non-system-tests/action.yml
+++ b/linting-and-non-system-tests/action.yml
@@ -52,8 +52,10 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: tmp/turbo_rspec_runtime.log
-        key: parallel-spec-non-system-runtimes-${{ github.sha }}
-        restore-keys: parallel-spec-non-system-runtimes-
+        key: parallel-spec-non-system-runtimes-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          parallel-spec-non-system-runtimes-${{ github.head_ref || github.ref_name }}-
+          parallel-spec-non-system-runtimes-
 
     - name: Setup Parallel Databases
       shell: bash
@@ -73,7 +75,7 @@ runs:
       uses: actions/cache/save@v5
       with:
         path: tmp/turbo_rspec_runtime.log
-        key: parallel-spec-non-system-runtimes-${{ github.sha }}
+        key: parallel-spec-non-system-runtimes-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
 
     - name: Publish Test Results
       uses: mikepenz/action-junit-report@v6

--- a/linting-and-non-system-tests/action.yml
+++ b/linting-and-non-system-tests/action.yml
@@ -79,7 +79,7 @@ runs:
 
     - name: Publish Test Results
       uses: mikepenz/action-junit-report@v6
-      if: success() || failure()
+      if: always()
       with:
         check_name: Test Results
         report_paths: tmp/rspec-*.xml

--- a/linting-and-non-system-tests/action.yml
+++ b/linting-and-non-system-tests/action.yml
@@ -52,7 +52,7 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: tmp/turbo_rspec_runtime.log
-        key: parallel-spec-non-system-runtimes-${{ github.sha }}_${{ github.run_attempt }}
+        key: parallel-spec-non-system-runtimes-${{ github.sha }}
         restore-keys: parallel-spec-non-system-runtimes-
 
     - name: Setup Parallel Databases
@@ -67,6 +67,13 @@ runs:
     - name: Run Rspec Tests
       shell: bash
       run: bundle exec parallel_rspec --verbose --exclude-pattern "/system/"
+
+    - name: Save Turbo-Test Runtime Stats
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: tmp/turbo_rspec_runtime.log
+        key: parallel-spec-non-system-runtimes-${{ github.sha }}
 
     - name: Publish Test Results
       uses: mikepenz/action-junit-report@v6

--- a/system-tests/action.yml
+++ b/system-tests/action.yml
@@ -66,7 +66,7 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: tmp/turbo_rspec_runtime.log
-        key: parallel-spec-system-runtimes-${{ github.sha }}_${{ github.run_attempt }}
+        key: parallel-spec-system-runtimes-${{ github.sha }}
         restore-keys: parallel-spec-system-runtimes-
 
     - name: Setup Parallel Databases
@@ -79,6 +79,13 @@ runs:
       env:
         GOOGLE_CHROME_BIN: ${{ case(inputs.web-driver == 'selenium', steps.setup-chrome.outputs.chrome-path, '') }}
         CAPYBARA_DRIVER: js
+
+    - name: Save Turbo-Test Runtime Stats
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: tmp/turbo_rspec_runtime.log
+        key: parallel-spec-system-runtimes-${{ github.sha }}
 
     - name: Publish Test Results
       uses: mikepenz/action-junit-report@v6

--- a/system-tests/action.yml
+++ b/system-tests/action.yml
@@ -91,7 +91,7 @@ runs:
 
     - name: Publish Test Results
       uses: mikepenz/action-junit-report@v6
-      if: success() || failure()
+      if: always()
       with:
         check_name: Test Results
         report_paths: tmp/rspec-*.xml

--- a/system-tests/action.yml
+++ b/system-tests/action.yml
@@ -66,8 +66,10 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: tmp/turbo_rspec_runtime.log
-        key: parallel-spec-system-runtimes-${{ github.sha }}
-        restore-keys: parallel-spec-system-runtimes-
+        key: parallel-spec-system-runtimes-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          parallel-spec-system-runtimes-${{ github.head_ref || github.ref_name }}-
+          parallel-spec-system-runtimes-
 
     - name: Setup Parallel Databases
       shell: bash
@@ -85,7 +87,7 @@ runs:
       uses: actions/cache/save@v5
       with:
         path: tmp/turbo_rspec_runtime.log
-        key: parallel-spec-system-runtimes-${{ github.sha }}
+        key: parallel-spec-system-runtimes-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
 
     - name: Publish Test Results
       uses: mikepenz/action-junit-report@v6


### PR DESCRIPTION
## Summary

`system-tests` and `linting-and-non-system-tests` both restore `tmp/turbo_rspec_runtime.log` from cache but never save it back — there's no matching `actions/cache/save` step in either action, unlike the asset cache which correctly has both. This means `parallel_rspec` has never actually had historical per-file timing data to balance work across workers; it's always splitting files by count instead of duration, in every repo using these actions.

Found this while migrating `c12_core` to the new shared `rails-ci.yml` workflow (which had the same restore-without-save bug, fixed separately there) — two re-runs of the same commit showed the rspec step vary from 2m27s to 1m15s, which initially looked like it might be cache-related but turned out to be flaky-retry variance instead. Digging into why the cache never seemed to help at all led here.

## Changes

- Added a `Save Turbo-Test Runtime Stats` step after `Run Rspec Tests` in both actions, `if: always()` so it saves even when tests fail.
- Dropped the `_${{ github.run_attempt }}` suffix from both cache keys — it only mattered for retry-safety on same-commit re-runs (avoiding a harmless "key already exists" warning on save), and `restore-keys` prefix fallback finds the most recent data either way.

## Test plan

- [ ] Verify a run with this fix produces a `Save Turbo-Test Runtime Stats` step that actually reports "Cache saved" rather than being skipped
- [ ] Verify a subsequent run on a new commit reports a cache hit against the previous commit's saved log via `restore-keys` prefix match

🤖 Generated with [Claude Code](https://claude.com/claude-code)