### PR TITLE
ci: surface lint/audit/brakeman failures in Test Results

### DIFF
--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -161,23 +161,32 @@ jobs:
             run: bundle exec rake parallel:create parallel:load_schema
 
           - name: Rubocop
+            id: rubocop
             if: ${{ inputs.rubocop_command }}
+            continue-on-error: true
             run: ${{ inputs.rubocop_command }}
 
           - name: Dependency Audit
+            id: dependency-audit
             if: ${{ inputs.dependency_audit_command }}
+            continue-on-error: true
             run: ${{ inputs.dependency_audit_command }}
 
           - name: ESLint
+            id: eslint
             if: ${{ inputs.js_lint_command }}
+            continue-on-error: true
             run: ${{ inputs.js_lint_command }}
 
           - name: Brakeman
+            id: brakeman
             if: ${{ inputs.brakeman_version }}
+            continue-on-error: true
             uses: reviewdog/action-brakeman@v2
             with:
               brakeman_version: ${{ inputs.brakeman_version }}
               reporter: github-pr-check
+              fail_level: error
 
           - name: Install Playwright Chromium Browser
             if: ${{ inputs.playwright && steps.cache-playwright.outputs.cache-hit != 'true' }}
@@ -191,6 +200,25 @@ jobs:
               restore-keys: |
                 parallel-spec-runtimes-${{ github.head_ref || github.ref_name }}-
                 parallel-spec-runtimes-
+
+      - name: Record Linter Results
+        if: always()
+        run: |
+          mkdir -p tmp
+          {
+            echo '<?xml version="1.0" encoding="UTF-8"?>'
+            echo '<testsuite name="Linters">'
+            for entry in "Rubocop:${{ steps.rubocop.outcome }}" "Dependency Audit:${{ steps.dependency-audit.outcome }}" "ESLint:${{ steps.eslint.outcome }}" "Brakeman:${{ steps.brakeman.outcome }}"; do
+              name="${entry%%:*}"
+              outcome="${entry##*:}"
+              case "$outcome" in
+                skipped|"") continue ;;
+                failure) echo "  <testcase name=\"$name\" classname=\"Linters\"><failure message=\"$name failed\"/></testcase>" ;;
+                *) echo "  <testcase name=\"$name\" classname=\"Linters\"/>" ;;
+              esac
+            done
+            echo '</testsuite>'
+          } > tmp/lint-results.xml
 
       - name: Save Asset Cache
         if: steps.cache-assets.outputs.cache-hit != 'true'
@@ -218,8 +246,24 @@ jobs:
         if: always()
         with:
           check_name: Test Results
-          report_paths: tmp/rspec-*.xml
+          report_paths: |
+            tmp/rspec-*.xml
+            tmp/lint-results.xml
           detailed_summary: true
+
+      - name: Check Linter Results
+        if: always()
+        run: |
+          failed=false
+          for entry in "Rubocop:${{ steps.rubocop.outcome }}" "Dependency Audit:${{ steps.dependency-audit.outcome }}" "ESLint:${{ steps.eslint.outcome }}" "Brakeman:${{ steps.brakeman.outcome }}"; do
+            name="${entry%%:*}"
+            outcome="${entry##*:}"
+            if [ "$outcome" = "failure" ]; then
+              echo "::error::$name failed"
+              failed=true
+            fi
+          done
+          [ "$failed" = false ]
 
       - name: Analyze Test Runtimes
         uses: RoleModel/actions/test-runtime-analyzer@v1


### PR DESCRIPTION
## Summary
- Rubocop, dependency-audit, and ESLint are plain caller-supplied shell commands, and Brakeman goes through reviewdog's own separate PR-check reporter — none of their pass/fail state flowed into the JUnit-based "Test Results" check that RSpec results use.
- Brakeman's `fail_level` also defaulted to `none`, so it never actually failed the job on real findings, just posted PR annotations.
- Gives each of these steps an `id` + `continue-on-error: true` so the job keeps going and their outcome is inspectable afterward, synthesizes a small JUnit fragment from those outcomes into `tmp/lint-results.xml`, feeds it into the same `report_paths` as the RSpec XML, and adds a final step that explicitly fails the job if any of them actually failed (`continue-on-error` otherwise masks that from the job's overall conclusion).

## Validation
Temporarily pointed `masifio-estates` at this branch (it exercises rubocop + dependency-audit + brakeman) and confirmed end-to-end:
- A real pre-existing `bundle-audit` finding now shows up in the "Test Results" check: "3 tests run, 2 passed, 1 failed" / "Dependency Audit failed"
- The job correctly fails overall (previously it wouldn't have, for a Brakeman-only finding, since `fail_level: none`)
- Reverted `masifio-estates` back to `@v3` afterward

Note: `actionlint` can't fully validate this file since it predates GitHub's `background`/`parallel` step keywords (shipped 2026-06-25) — validated live instead.

## Test plan
- [x] Live-tested against masifio-estates, confirmed correct pass/fail propagation into Test Results
- [ ] Merge, tag a new release, point app repos at it