### PR TITLE
ci: tighten rails-ci step dependencies, bump stale action pins

### DIFF
--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -102,6 +102,8 @@ jobs:
 
       # Ruby/gems and apt packages background immediately; corepack → node → yarn
       # chain in the foreground so yarn install can overlap with the slow installs.
+      # Below, gem-only and yarn-only steps are unblocked as soon as their one
+      # real dependency finishes, rather than all waiting on each other.
       - name: Install Ruby and Gems
         id: install-ruby
         uses: ruby/setup-ruby@v1
@@ -137,6 +139,7 @@ jobs:
           cache: yarn
 
       - name: Install Yarn Packages
+        id: install-yarn
         if: ${{ hashFiles('yarn.lock') != '' }}
         run: yarn install --immutable
         background: true
@@ -150,88 +153,119 @@ jobs:
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
         background: true
 
-      - wait-all:
+      # No dependencies of its own, so it can fire immediately too.
+      - name: Load Previous Turbo-Test Runtime Stats
+        uses: actions/cache/restore@v6
+        with:
+          path: tmp/turbo_rspec_runtime.log
+          key: parallel-spec-runtimes-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            parallel-spec-runtimes-${{ github.head_ref || github.ref_name }}-
+            parallel-spec-runtimes-
+        background: true
 
-      - parallel:
-          - name: Compile Assets
-            if: ${{ steps.cache-assets.outputs.cache-hit != 'true' }}
-            run: bundle exec rails assets:precompile
+      # Gem-only work can start as soon as gems are ready, instead of waiting
+      # on node/yarn/assets too.
+      - wait: [install-ruby]
 
-          - name: Setup Parallel Databases
-            run: bundle exec rake parallel:create parallel:load_schema
+      - name: Setup Parallel Databases
+        run: bundle exec rake parallel:create parallel:load_schema
+        background: true
 
-          - name: Rubocop
-            if: ${{ inputs.rubocop_command }}
-            run: ${{ inputs.rubocop_command }}
+      - name: Rubocop
+        if: ${{ inputs.rubocop_command }}
+        run: ${{ inputs.rubocop_command }}
+        background: true
 
-          - name: Dependency Audit
-            if: ${{ inputs.dependency_audit_command }}
-            run: ${{ inputs.dependency_audit_command }}
+      - name: Dependency Audit
+        if: ${{ inputs.dependency_audit_command }}
+        run: ${{ inputs.dependency_audit_command }}
+        background: true
 
-          - name: ESLint
-            if: ${{ inputs.js_lint_command }}
-            run: ${{ inputs.js_lint_command }}
+      - name: Brakeman
+        if: ${{ inputs.brakeman_version }}
+        uses: reviewdog/action-brakeman@v2
+        with:
+          brakeman_version: ${{ inputs.brakeman_version }}
+          reporter: github-pr-check
+        background: true
 
-          - name: Brakeman
-            if: ${{ inputs.brakeman_version }}
-            uses: reviewdog/action-brakeman@v2
-            with:
-              brakeman_version: ${{ inputs.brakeman_version }}
-              reporter: github-pr-check
+      # Yarn-only work can start as soon as node_modules are ready.
+      - wait: [install-yarn]
 
-          - name: Install Playwright Chromium Browser
-            if: ${{ inputs.playwright && steps.cache-playwright.outputs.cache-hit != 'true' }}
-            run: yarn playwright install --with-deps chromium
+      - name: ESLint
+        if: ${{ inputs.js_lint_command }}
+        run: ${{ inputs.js_lint_command }}
+        background: true
 
-          - name: Load Previous Turbo-Test Runtime Stats
-            uses: actions/cache/restore@v6
-            with:
-              path: tmp/turbo_rspec_runtime.log
-              key: parallel-spec-runtimes-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
-              restore-keys: |
-                parallel-spec-runtimes-${{ github.head_ref || github.ref_name }}-
-                parallel-spec-runtimes-
+      # Needs gems + yarn (both already waited-for above) and the asset cache
+      # lookup, but nothing from apt_packages or the playwright cache.
+      - wait: [cache-assets]
 
+      - name: Compile Assets
+        if: ${{ steps.cache-assets.outputs.cache-hit != 'true' }}
+        run: bundle exec rails assets:precompile
+        background: true
+
+      - wait: [cache-playwright]
+
+      - name: Install Playwright Chromium Browser
+        if: ${{ inputs.playwright && steps.cache-playwright.outputs.cache-hit != 'true' }}
+        run: yarn playwright install --with-deps chromium
+        background: true
+
+      - wait-all: true
+
+      # Doesn't need to finish before tests start, only before the job ends —
+      # the wait below is a cheap correctness net, not an expected delay,
+      # since the upload finishes long before the test run does.
       - name: Save Asset Cache
         if: steps.cache-assets.outputs.cache-hit != 'true'
+        id: save-asset-cache
         uses: actions/cache/save@v6
         with:
           path: |
             public/assets
             app/assets/builds
           key: ${{ steps.cache-assets.outputs.cache-primary-key }}
+        background: true
 
       - name: Run Rspec Tests
         run: bundle exec parallel_rspec --verbose spec/
         env:
           CAPYBARA_DRIVER: js
 
-      - name: Save Turbo-Test Runtime Stats
-        if: always()
-        uses: actions/cache/save@v6
-        with:
-          path: tmp/turbo_rspec_runtime.log
-          key: parallel-spec-runtimes-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+      - wait: [save-asset-cache]
 
-      - name: Publish Test Results
-        uses: mikepenz/action-junit-report@v6
-        if: always()
-        with:
-          check_name: Test Results
-          report_paths: tmp/rspec-*.xml
-          detailed_summary: true
+      # None of these read each other's output — all four only consume
+      # artifacts already produced by Run Rspec Tests above.
+      - parallel:
+          - name: Save Turbo-Test Runtime Stats
+            if: always()
+            uses: actions/cache/save@v6
+            with:
+              path: tmp/turbo_rspec_runtime.log
+              key: parallel-spec-runtimes-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
 
-      - name: Analyze Test Runtimes
-        uses: RoleModel/actions/test-runtime-analyzer@v1
-        with:
-          test-output-path: tmp/turbo_rspec_runtime.log
+          - name: Publish Test Results
+            uses: mikepenz/action-junit-report@v6
+            if: always()
+            with:
+              check_name: Test Results
+              report_paths: tmp/rspec-*.xml
+              detailed_summary: true
 
-      - name: Upload Screenshots
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: rspec-screenshots
-          path: tmp/capybara
+          - name: Analyze Test Runtimes
+            uses: RoleModel/actions/test-runtime-analyzer@v1
+            with:
+              test-output-path: tmp/turbo_rspec_runtime.log
+
+          - name: Upload Screenshots
+            if: failure()
+            uses: actions/upload-artifact@v7
+            with:
+              name: rspec-screenshots
+              path: tmp/capybara
 
       - name: Cleanup
         uses: RoleModel/actions/test-cleanup@v1

--- a/.github/workflows/staging-auto-merge-ci.yml
+++ b/.github/workflows/staging-auto-merge-ci.yml
@@ -16,7 +16,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/version-and-tag.yml
+++ b/.github/workflows/version-and-tag.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: '0'
 

--- a/compile-assets/action.yml
+++ b/compile-assets/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Check for Existing Precompiled Assets
       id: check-asset-cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: |
           public/assets
@@ -47,7 +47,7 @@ runs:
     - name: Cache Rails Precompiled Assets
       if: ${{ steps.check-asset-cache.outputs.cache-hit != 'true' }}
       id: lookup-cached-assets
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@v6
       with:
         path: |
           public/assets

--- a/linting-and-non-system-tests/action.yml
+++ b/linting-and-non-system-tests/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Retrieve Cached Rails Assets
       id: cache-assets
       if: ${{ inputs.needs-compiled-assets == 'true' }}
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: |
           public/assets
@@ -49,7 +49,7 @@ runs:
 
     - name: Load Previous Turbo-Test Runtime Stats
       id: restore-parallel-spec
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: tmp/turbo_rspec_runtime.log
         key: parallel-spec-non-system-runtimes-${{ github.sha }}_${{ github.run_attempt }}

--- a/system-tests/action.yml
+++ b/system-tests/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Check Playwright Cache
       if: inputs.web-driver == 'playwright'
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright
@@ -53,7 +53,7 @@ runs:
 
     - name: Retrieve Cached Rails Assets
       id: cache-assets
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: |
           public/assets
@@ -63,7 +63,7 @@ runs:
 
     - name: Load Previous Turbo-Test Runtime Stats
       id: restore-parallel-spec
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: tmp/turbo_rspec_runtime.log
         key: parallel-spec-system-runtimes-${{ github.sha }}_${{ github.run_attempt }}
@@ -95,7 +95,7 @@ runs:
 
     - name: Upload Screenshots
       if: failure()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: rspec-screenshots
         path: ${{ inputs.failure-screenshot-dir }}


### PR DESCRIPTION
## Summary
- Rework `rails-ci.yml`'s background/wait ordering so each step (Setup Parallel Databases, Rubocop, Dependency Audit, Brakeman, ESLint, Compile Assets, Playwright install) starts as soon as its actual dependency is ready, instead of all waiting on a single `wait-all` barrier gated by the slowest unrelated install.
- Let the asset-cache upload run in the background so it overlaps with the test run instead of blocking it.
- Fold the independent post-test reporting steps (runtime stats cache, JUnit publish, runtime analysis, screenshot upload) into a single `parallel:` block since none of them depend on each other.
- Bump stale `actions/cache`, `actions/checkout`, and `actions/upload-artifact` pins to their latest majors across the composite actions for consistency.

## Test plan
- [ ] Point a consuming app's workflow at this branch (`@claude/rails-ci-parallel-db-setup-e51d6b`) and confirm a full CI run passes
- [ ] Confirm Setup Parallel Databases / Rubocop / Brakeman / ESLint / Compile Assets still gate correctly when their upstream `if:` conditions are false (no yarn.lock, no rubocop_command, etc.)
- [ ] Confirm Rspec run + reporting steps still produce correct check runs and artifacts on both success and failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)