### PR TITLE
Export GOOGLE_CHROME_BIN from preinstalled Chrome [Minor]

### DIFF
--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -117,6 +117,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ${{ inputs.apt_packages }}
         background: true
 
+      - name: Find Preinstalled Chrome
+        run: echo "GOOGLE_CHROME_BIN=$(which google-chrome || which google-chrome-stable)" >> "$GITHUB_ENV"
+        background: true
+
       - name: Restore Asset Cache
         id: cache-assets
         uses: actions/cache/restore@v6


### PR DESCRIPTION
## Summary
- Some Rails apps shell out to Chrome directly (e.g. server-side PDF generation via `system("... $GOOGLE_CHROME_BIN ...")`) rather than only using it through a browser-driver gem, and previously had to carry their own Setup Chrome step in their own `ci.yml` to get that path.
- Blacksmith's ubuntu runner images already ship Chrome, so this just resolves it with `which` in a background step alongside the other early setup steps, and exports `GOOGLE_CHROME_BIN` for the rest of the job.

## Test plan
- [ ] private repo is temporarily pointing its CI at this branch to confirm PDF-generation specs pass with the exported path