### PR TITLE
Mount Postgres data dir on tmpfs in CI [Minor]

### DIFF
--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -85,6 +85,11 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
+        # Test data is throwaway every run, so put the data dir on tmpfs to
+        # eliminate checkpoint/fsync disk waits entirely — a slow-disk stall
+        # can't happen if there's no disk in the path.
+        options: >-
+          --tmpfs /var/lib/postgresql/data:rw,size=2g
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Why

We have been getting timeouts on some CI runs for FMI that appear to be related to disk usage. 

## What

Test data is thrown away every CI run, so there's no reason it should ever touch real disk. This mounts the Postgres data directory on tmpfs via the service container's `options`, eliminating checkpoint/fsync disk waits entirely rather than throwing more disk throughput at the problem.

```yaml
services:
  postgres:
    image: postgres:${{ inputs.postgres_version }}
    options: >-
      --tmpfs /var/lib/postgresql/data:rw,size=2g
```

2g should comfortably cover typical test-suite data footprints; can be bumped if a consuming repo needs more.

## Rollout

Consuming repos pick this up by bumping their `rails-ci.yml@vX.Y.Z` pin once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)